### PR TITLE
Fix: path for PhpStorm inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create `ruleset.xml` in root of your project.
 <?xml version="1.0"?>
 <ruleset name="YourProject">
     <!-- Extending rulesets -->
-    <rule ref="vendor/ninjify/coding-standard/ruleset.xml" />
+    <rule ref="./../../ninjify/coding-standard/ruleset.xml" />
 
     <!-- My rules -->
     

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -172,7 +172,7 @@
     <!-- ########################################################################################################### -->
     <!-- Slevomat Coding Standard -->
     <!-- ########################################################################################################### -->
-    <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
+    <rule ref="./../../slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
         <exclude name="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>


### PR DESCRIPTION
path 

> vendor/ninjify/coding-standard/ruleset.xml

  is not working in PhpStorm inspection, please use 

> ./../../slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml

or

> ./../../../vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml