### PR TITLE
All annotations are useful

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -330,6 +330,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
         <properties>
             <property name="enableEachParameterAndReturnInspection" value="true"/>
+            <property name="allAnnotationsAreUseful" value="true"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces">


### PR DESCRIPTION
With this change will be comments with only doctrine annotations no more reported as useless.

Currently is reported:
```
/**
 * @Path("/users")
 * @Method("GET")
 */
```

Currently is *NOT* reported:
```
/**
 * Practically the same
 * @Path("/users")
 * @Method("GET")
 */
```