### PR TITLE
slevomat/coding-standard v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tuned & very strict coding standards for PHP projects. Trusted by [Contributte](https://github.com/contributte), [Apitte](https://github.com/apitte), [Nettrine](https://github.com/nettrine)
 and many others projects.
 
-This library use sniffs from [slevomat/coding-standards](https://github.com/slevomat/coding-standards) and ruleset definitions are based on [consistence/coding-standard](https://github.com/consistence/coding-standard) and [doctrine/coding-standard](https://github.com/doctrine/coding-standard). Thank yu guys.
+This library use sniffs from [slevomat/coding-standard](https://github.com/slevomat/coding-standard) and ruleset definitions are based on [consistence/coding-standard](https://github.com/consistence/coding-standard) and [doctrine/coding-standard](https://github.com/doctrine/coding-standard). Thank yu guys.
 
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "slevomat/coding-standard": "~4.8.6",
+    "slevomat/coding-standard": "~5.0.0",
     "squizlabs/php_codesniffer": "^3.3.1"
   },
   "extra": {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -237,11 +237,21 @@
         <exclude name="SlevomatCodingStandard.PHP.UselessParentheses.UselessParentheses"/>
         <exclude name="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable"/>
         <exclude name="SlevomatCodingStandard.Variables.UselessVariable.UselessVariable"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint"/> <!-- Mixed is used too often - in all configurations -->
+        <exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax.DisallowedArrayTypeHintSyntax"/> <!-- Disabled until generics are widely supported -->
+        <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/> <!-- Disabled for support of php < 7.3 -->
     </rule>
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>
             <property name="fixable" type="boolean" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
+        <properties>
+            <property name="linesCountAfterOpeningBrace" value="1"/>
+            <property name="linesCountBeforeClosingBrace" value="1"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
@@ -283,7 +293,6 @@
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
@@ -321,6 +330,7 @@
             <property name="linesCountBetweenUseTypes" value="0"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
@@ -341,12 +351,6 @@
         <properties>
             <property name="enableEachParameterAndReturnInspection" value="true"/>
             <property name="allAnnotationsAreUseful" value="true"/>
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces">
-        <properties>
-            <property name="linesCountAfterOpeningBrace" value="1"/>
-            <property name="linesCountBeforeClosingBrace" value="1"/>
         </properties>
     </rule>
 </ruleset>


### PR DESCRIPTION
Summary:
- disabled new sniff which requires trailing comma in multiline function call to keep compatibility with php < 7.3
- disabled generics syntax requirement for arrays - not well supported by phpstorm yet (supported only for writing typehint, not for autocompletetion from that typed array)
- disabled mixed typehint report as it reported also `mixed[]` which is widely used in configuration
- checks fails for an `if` without curly braces, following sniffs removed support
	- `SlevomatCodingStandard.ControlStructures.ControlStructureSpacing`
	- `SlevomatCodingStandard.ControlStructures.RequireTernaryOperator`
	- `SlevomatCodingStandard.ControlStructures.EarlyExit`
	- `SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn`

ℹ️ Run sniffer without cache during update. Failing sniffs with removed support for ifs without curly braces throws exception which cause that all excluded sniffs are reported.