### PR TITLE
Remove SlevomatCodingStandard.Functions.UselessParameterDefaultValue

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -241,6 +241,7 @@
         <exclude name="SlevomatCodingStandard.PHP.UselessParentheses.UselessParentheses"/>
         <exclude name="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable"/>
         <exclude name="SlevomatCodingStandard.Variables.UselessVariable.UselessVariable"/>
+        <exclude name="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
         <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint"/> <!-- Mixed is used too often - in all configurations -->
         <exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax.DisallowedArrayTypeHintSyntax"/> <!-- Disabled until generics are widely supported -->
     </rule>


### PR DESCRIPTION
I have no idea how this sniff was even created and what's the purpose...
but it's not really something that is usable, plus it breaks your code...

for example 

```php
...
public function __construct(string $a = 'something', string $b = 'b', ...$parameters); //this triggers error and it will be changed to
public function __construct(string $a, string $b, ...$parameters); 

```