### PR TITLE
deprecated slevomat sniffs

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -226,7 +226,6 @@
             <property name="linesCountBeforeClosingBrace" value="1"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming">
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
     </rule>
@@ -352,7 +351,6 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation">
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation.NonFullyQualifiedClassName"/>
     </rule>


### PR DESCRIPTION
Deprecated SlevomatCodingStandard.Classes.UnusedPrivateElements (ref: https://phpstan.org/blog/detecting-unused-private-properties-methods-constants, https://github.com/slevomat/coding-standard/commit/bcbf756f05979a05b1ae2b7a8ed6796f060cfa83)

Deprecated SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword (ref: https://github.com/slevomat/coding-standard/commit/08388d83d9c9d79745bc8c5fec609fc494ab582e)